### PR TITLE
Hide transaction history for Card Details screen

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -722,6 +722,9 @@ button.fpg-btn.fpg-btn-large {
       color: #333333;
       font-size: 16px; }
 
+.cardDetail-page transaction-list {
+  display: none; }
+
 .fp-card-detail-dan {
   margin: 20px 20px 0;
   text-align: center; }

--- a/dist/lang/en.json
+++ b/dist/lang/en.json
@@ -204,7 +204,7 @@
     },
     "terms_and_conditions": "Terms and Conditions",
     "today": "Today",
-    "transactions": "Transactions",
+    "transactions": "Device-Specific Transactions (Provided by Issuer)",
     "transaction_status": {
       "approved": "Approved",
       "declined": "Declined",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -204,7 +204,7 @@
     },
     "terms_and_conditions": "Terms and Conditions",
     "today": "Today",
-    "transactions": "Transactions",
+    "transactions": "Device-Specific Transactions (Provided by Issuer)",
     "transaction_status": {
       "approved": "Approved",
       "declined": "Declined",

--- a/src/scss/pages/_card-detail.scss
+++ b/src/scss/pages/_card-detail.scss
@@ -82,6 +82,11 @@
             }
         }
     }
+
+    // Hide transaction history on Card Details page
+    transaction-list {
+        display: none;
+    }
 } // END .cardDetail-page
 
 // Device Account Number display


### PR DESCRIPTION
First, the title of `Transactions` is updated to reflect that these are device-specific and provided by the issuer. Unfortunately we cannot easily add any additional information under this title, but this should be fine since we're also hiding this entire block using CSS.